### PR TITLE
Fix for nonexistent outdir

### DIFF
--- a/examples/_template/js/build/nextron-build.js
+++ b/examples/_template/js/build/nextron-build.js
@@ -63,7 +63,7 @@ async function build(args) {
     await remove(join(cwd, 'dist'))
 
     spinner.create('Building renderer process')
-    const outdir = join(cwd, 'renderer/out')
+    const outdir = join(cwd, 'renderer/.next')
     const appdir = join(cwd, 'app')
     await npx('next', ['build', 'renderer'], { cwd })
     await npx('next', ['export', 'renderer'], { cwd })

--- a/examples/_template/ts/build/nextron-build.js
+++ b/examples/_template/ts/build/nextron-build.js
@@ -63,7 +63,7 @@ async function build(args) {
     await remove(join(cwd, 'dist'))
 
     spinner.create('Building renderer process')
-    const outdir = join(cwd, 'renderer/out')
+    const outdir = join(cwd, 'renderer/.next')
     const appdir = join(cwd, 'app')
     await npx('next', ['build', 'renderer'], { cwd })
     await npx('next', ['export', 'renderer'], { cwd })


### PR DESCRIPTION
I didn't have the time to go deeper in this issue, but basically the `out` dir inside `renderer` is now being created as `.next`.

So, in order to others don't have to spend time on debugging the building error until tracking to this I think would be nice if we update the outdir.

Please, correct me if anything I've done is not as expected.

Thanks in advance.