### PR TITLE
Add webPreferences to main/helpers/create-window.[js/ts]

### DIFF
--- a/examples/_template/js/main/helpers/create-window.js
+++ b/examples/_template/js/main/helpers/create-window.js
@@ -71,6 +71,7 @@ export default function createWindow(windowName, options) {
     ...state,
     webPreferences: {
       nodeIntegration: true,
+      ...options.webPreferences,
     },
   });
 

--- a/examples/_template/ts/main/helpers/create-window.ts
+++ b/examples/_template/ts/main/helpers/create-window.ts
@@ -72,6 +72,7 @@ export default (windowName: string, options: BrowserWindowConstructorOptions): B
     ...state,
     webPreferences: {
       nodeIntegration: true,
+      ...options.webPreferences,
     },
   };
   win = new BrowserWindow(browserOptions);


### PR DESCRIPTION
Hi.

I use typescript template for local file edit or so on.
So I set a `webPreference.webSecurity:false` on createWindow, I have to read local file. but `not allowed to load local resource` forever.

So I check create-window.ts, webPreference option is always only `webPreference.nodeIntegration:true`.

please check this PR, thanks.