### PR TITLE
Replace <html> by <Html> in custom documents

### DIFF
--- a/examples/with-javascript-ant-design/renderer/pages/_document.jsx
+++ b/examples/with-javascript-ant-design/renderer/pages/_document.jsx
@@ -1,9 +1,9 @@
-import Document, { Head, Main, NextScript } from 'next/document';
+import Document, { Html, Head, Main, NextScript } from 'next/document';
 
 export default class MyDocument extends Document {
   render () {
     return (
-      <html>
+      <Html>
         <Head>
           <meta name='viewport' content='width=device-width, initial-scale=1' />
           <meta charSet='utf-8' />
@@ -12,7 +12,7 @@ export default class MyDocument extends Document {
           <Main />
           <NextScript />
         </body>
-      </html>
+      </Html>
     );
   }
 };

--- a/examples/with-javascript-emotion/renderer/pages/_document.jsx
+++ b/examples/with-javascript-emotion/renderer/pages/_document.jsx
@@ -1,11 +1,11 @@
 import React from 'react';
-import Document, { Head, Main, NextScript } from 'next/document';
+import Document, { Html, Head, Main, NextScript } from 'next/document';
 import { css, Global } from '@emotion/core';
 
 class MyDocument extends Document {
   render() {
     return (
-      <html lang="en">
+      <Html lang="en">
         <Head>
           <meta charSet="utf-8" />
           <meta name="viewport" content={'user-scalable=0, initial-scale=1, minimum-scale=1, width=device-width, height=device-height'} />
@@ -30,7 +30,7 @@ class MyDocument extends Document {
           <Main />
           <NextScript />
         </body>
-      </html>
+      </Html>
     );
   }
 }

--- a/examples/with-javascript-material-ui/renderer/pages/_document.jsx
+++ b/examples/with-javascript-material-ui/renderer/pages/_document.jsx
@@ -1,12 +1,12 @@
 import React from 'react';
-import Document, { Head, Main, NextScript } from 'next/document';
+import Document, { Html, Head, Main, NextScript } from 'next/document';
 import { ServerStyleSheets } from '@material-ui/styles';
 import { theme } from '../lib/theme';
 
 export default class MyDocument extends Document {
   render() {
     return (
-      <html lang="en" dir="ltr">
+      <Html lang="en" dir="ltr">
         <Head>
           <meta name="theme-color" content={theme.palette.primary.main} />
           <link
@@ -18,7 +18,7 @@ export default class MyDocument extends Document {
           <Main />
           <NextScript />
         </body>
-      </html>
+      </Html>
     );
   }
 }

--- a/examples/with-typescript-emotion/renderer/pages/_document.tsx
+++ b/examples/with-typescript-emotion/renderer/pages/_document.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
-import Document, { Head, Main, NextScript } from 'next/document';
+import Document, { Html, Head, Main, NextScript } from 'next/document';
 import { css, Global } from '@emotion/core';
 
 class MyDocument extends Document {
   render() {
     return (
-      <html lang="en">
+      <Html lang="en">
         <Head>
           <meta charSet="utf-8" />
           <meta name="viewport" content={'user-scalable=0, initial-scale=1, minimum-scale=1, width=device-width, height=device-height'} />
@@ -30,7 +30,7 @@ class MyDocument extends Document {
           <Main />
           <NextScript />
         </body>
-      </html>
+      </Html>
     );
   }
 }

--- a/examples/with-typescript-material-ui/renderer/pages/_document.tsx
+++ b/examples/with-typescript-material-ui/renderer/pages/_document.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
-import Document, { Head, Main, NextScript } from 'next/document';
+import Document, { Html, Head, Main, NextScript } from 'next/document';
 import { ServerStyleSheets } from '@material-ui/styles';
 import { theme } from '../lib/theme';
 
 export default class MyDocument extends Document {
   render() {
     return (
-      <html lang="en" dir="ltr">
+      <Html lang="en" dir="ltr">
         <Head>
           <meta name="theme-color" content={theme.palette.primary.main} />
           <link
@@ -18,7 +18,7 @@ export default class MyDocument extends Document {
           <Main />
           <NextScript />
         </body>
-      </html>
+      </Html>
     );
   }
 }

--- a/examples/with-typescript-python-api/renderer/pages/_document.tsx
+++ b/examples/with-typescript-python-api/renderer/pages/_document.tsx
@@ -2,7 +2,7 @@
 // _document is only rendered on the server side and not on the client side
 // Event handlers like onClick can't be added to this file
 //
-import Document, { Head, Main, NextScript } from "next/document";
+import Document, { Html, Head, Main, NextScript } from "next/document";
 import { css } from "./_document.css";
 
 export default class MyDocument extends Document {
@@ -13,7 +13,7 @@ export default class MyDocument extends Document {
 
   public render() {
     return (
-      <html>
+      <Html>
         <Head>
           <meta content="text/html; charset=utf-8"/>
           <meta name="viewport" content="width=device-width, initial-scale=1"/>
@@ -58,7 +58,7 @@ if (typeof(require) === "undefined") {
 ` }}
           />
         </body>
-      </html>
+      </Html>
     );
   }
 }


### PR DESCRIPTION
Gets rid of the following message:

```
Expected Document Component Html was not rendered. Make sure you render them in your custom `_document`
See more info here https://err.sh/next.js/missing-document-component
```