### PR TITLE
Support static properties in the main process

### DIFF
--- a/lib/webpack/webpack.config.ts
+++ b/lib/webpack/webpack.config.ts
@@ -29,7 +29,10 @@ export default (env: 'development' | 'production'): webpack.Configuration => ({
           options: {
             cacheDirectory: true,
             presets: ['@babel/preset-typescript'],
-            plugins: ['@babel/plugin-proposal-optional-chaining'],
+            plugins: [
+              '@babel/plugin-proposal-class-properties',
+              '@babel/plugin-proposal-optional-chaining',
+            ],
           },
         },
         exclude: [


### PR DESCRIPTION
After merging and fixing #97 I encountered another similar problem...

I was getting the following error
```
./main/outputters/middleware/rotator.ts 4:24
Module parse failed: Unexpected token (4:24)
File was processed with these loaders:
 * ./node_modules/babel-loader/lib/index.js
You may need an additional loader to handle the result of these loaders.
| import { Outputter } from '..';
| export class OutputRotator extends Outputter {
>   static defaultOptions = {
|     rotationTime: 7500,
|     waitingTime: 2000,
```

which means, `static` properties are not supported (in main process)

Again, this is fixed by adding the `@babel/plugin-proposal-class-properties` plugin... but it makes me doubt... shouldn't all of this be supported already by having 
```
presets: ['@babel/preset-typescript'],
```

is there something wrong here?
Just want to confirm **before** merging this PR...