### PR TITLE
Fixed next/head, next/link bug in example with-javascript-ant-design

### DIFF
--- a/examples/with-javascript-ant-design/renderer/pages/home.jsx
+++ b/examples/with-javascript-ant-design/renderer/pages/home.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import Head from 'next/Head';
-import Link from 'next/Link';
+import Head from 'next/head';
+import Link from 'next/link';
 import {
   Layout,
   Form,

--- a/examples/with-javascript-ant-design/renderer/pages/next.jsx
+++ b/examples/with-javascript-ant-design/renderer/pages/next.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import Head from 'next/Head';
-import Link from 'next/Link';
+import Head from 'next/head';
+import Link from 'next/link';
 import {
   Layout,
   Result,


### PR DESCRIPTION
Changed followings:
- next/Head -> next/head
- next/Link -> next/link

I faced error messaged during building example.
```
ModuleNotFoundError: Module not found: Error: Can't resolve 'next/Head' in '/home/yschung/workspace/my-app/renderer/pages'
```

Official [nextjs document](https://nextjs.org/docs/api-reference/next/head) uses 'next/head', not 'next/Head'

Tested on
- next: 10.0.6
- nextron: 6.0.3