### PR TITLE
Add with-typescript-ant-design example

### DIFF
--- a/README.md
+++ b/README.md
@@ -376,6 +376,21 @@ $ yarn create nextron-app my-app --example with-typescript
 $ pnpx create-nextron-app my-app --example with-typescript
 ```
 
+### [examples/with-typescript-ant-design](./examples/with-typescript-ant-design)
+
+<p align="center"><img src="https://i.imgur.com/NrkTPe9.png"></p>
+
+```
+# with npm
+$ npm init nextron-app my-app --example with-typescript-ant-design
+
+# with yarn
+$ yarn create nextron-app my-app --example with-typescript-ant-design
+
+# with pnpx
+$ pnpx create-nextron-app my-app --example with-typescript-ant-design
+```
+
 ### [examples/with-typescript-emotion](./examples/with-typescript-emotion)
 
 <p align="center"><img src="https://i.imgur.com/3UKgyH7.png"></p>

--- a/examples/with-typescript-ant-design/README.md
+++ b/examples/with-typescript-ant-design/README.md
@@ -1,0 +1,42 @@
+<p align="center"><img src="https://i.imgur.com/NrkTPe9.png"></p>
+
+## Usage
+
+### Create an App
+
+```
+# with npm
+$ npm init nextron-app my-app --example with-typescript-ant-design
+
+# with yarn
+$ yarn create nextron-app my-app --example with-typescript-ant-design
+
+# with pnpx
+$ pnpx create-nextron-app my-app --example with-typescript-ant-design
+```
+
+### Install Dependencies
+
+```
+$ cd my-app
+
+# using yarn or npm
+$ yarn (or `npm install`)
+
+# using pnpm
+$ pnpm install --shamefully-hoist
+```
+
+### Use it
+
+```
+# development mode
+$ yarn dev (or `npm run dev` or `pnpm run dev`)
+
+# production build
+$ yarn build (or `npm run build` or `pnpm run build`)
+```
+
+## Resources
+
+<https://ant.design>

--- a/examples/with-typescript-ant-design/electron-builder.yml
+++ b/examples/with-typescript-ant-design/electron-builder.yml
@@ -1,0 +1,12 @@
+appId: com.example.nextron
+productName: My Nextron App
+copyright: Copyright © 2018 Yoshihide Shiono
+directories:
+  output: dist
+  buildResources: resources
+files:
+  - from: .
+    filter:
+      - package.json
+      - app
+publish: null

--- a/examples/with-typescript-ant-design/package.json
+++ b/examples/with-typescript-ant-design/package.json
@@ -1,0 +1,37 @@
+{
+  "private": true,
+  "name": "my-nextron-app",
+  "description": "My application description",
+  "version": "1.0.0",
+  "author": "Yoshihide Shiono <shiono.yoshihide@gmail.com>",
+  "main": "app/background.js",
+  "scripts": {
+    "dev": "nextron",
+    "build": "nextron build",
+    "postinstall": "electron-builder install-app-deps"
+  },
+  "dependencies": {
+    "electron-serve": "^1.1.0",
+    "electron-store": "^7.0.2"
+  },
+  "devDependencies": {
+    "@babel/core": "^7.12.9",
+    "@zeit/next-css": "^1.0.1",
+    "@types/node": "^14.6.4",
+    "@types/react": "^16.9.49",
+    "@types/react-dom": "^16.9.8",
+    "@babel/preset-typescript": "^7.13.0",
+    "antd": "^4.8.6",
+    "babel-loader": "^8.2.2",
+    "babel-plugin-import": "^1.13.3",
+    "electron": "^11.3.0",
+    "electron-builder": "^22.9.1",
+    "next": "^10.0.7",
+    "nextron": "^6.0.4",
+    "null-loader": "^4.0.1",
+    "react": "^17.0.1",
+    "react-dom": "^17.0.1",
+    "webpack": "4.44.1",
+    "typescript": "^4.2.2"
+  }
+}

--- a/examples/with-typescript-ant-design/renderer/.babelrc
+++ b/examples/with-typescript-ant-design/renderer/.babelrc
@@ -1,0 +1,15 @@
+{
+  "presets": [
+    "next/babel",
+    "@babel/preset-typescript"
+  ],
+  "plugins": [
+    [
+      "import",
+      {
+        "libraryName": "antd",
+        "style": "css"
+      }
+    ]
+  ]
+}

--- a/examples/with-typescript-ant-design/renderer/next.config.js
+++ b/examples/with-typescript-ant-design/renderer/next.config.js
@@ -1,0 +1,30 @@
+const withCss = require('@zeit/next-css');
+
+module.exports = withCss({
+  webpack: (config, { isServer }) => {
+    config.target = 'electron-renderer';
+
+    if (isServer) {
+      const antStyles = /antd\/.*?\/style\/css.*?/;
+      const origExternals = [...config.externals];
+      config.externals = [
+        (context, request, callback) => {
+          if (request.match(antStyles)) return callback();
+          if (typeof origExternals[0] === 'function') {
+            origExternals[0](context, request, callback);
+          } else {
+            callback();
+          }
+        },
+        ...(typeof origExternals[0] === 'function' ? [] : origExternals),
+      ];
+
+      config.module.rules.unshift({
+        test: antStyles,
+        use: 'null-loader',
+      });
+    }
+
+    return config
+  },
+});

--- a/examples/with-typescript-ant-design/renderer/pages/_app.tsx
+++ b/examples/with-typescript-ant-design/renderer/pages/_app.tsx
@@ -1,5 +1,4 @@
 import type { AppProps } from 'next/app'
-import '../styles/index.css'
 import Head from 'next/head'
 
 import 'antd/dist/antd.css';
@@ -10,7 +9,7 @@ const MyApp = ({ Component, pageProps }: AppProps) => {
       <Head>
         <title>Home - Nextron (with-typescript-ant-design)</title>
       </Head>
-      
+
       <Component {...pageProps} />
     </>
   )

--- a/examples/with-typescript-ant-design/renderer/pages/_app.tsx
+++ b/examples/with-typescript-ant-design/renderer/pages/_app.tsx
@@ -1,0 +1,19 @@
+import type { AppProps } from 'next/app'
+import '../styles/index.css'
+import Head from 'next/head'
+
+import 'antd/dist/antd.css';
+
+const MyApp = ({ Component, pageProps }: AppProps) => {
+  return (
+    <>
+      <Head>
+        <title>Home - Nextron (with-typescript-ant-design)</title>
+      </Head>
+      
+      <Component {...pageProps} />
+    </>
+  )
+}
+
+export default MyApp

--- a/examples/with-typescript-ant-design/renderer/pages/_document.tsx
+++ b/examples/with-typescript-ant-design/renderer/pages/_document.tsx
@@ -1,0 +1,18 @@
+import Document, { Html, Head, Main, NextScript } from 'next/document';
+
+export default class MyDocument extends Document {
+  render () {
+    return (
+      <Html>
+        <Head>
+          <meta name='viewport' content='width=device-width, initial-scale=1' />
+          <meta charSet='utf-8' />
+        </Head>
+        <body>
+          <Main />
+          <NextScript />
+        </body>
+      </Html>
+    );
+  }
+};

--- a/examples/with-typescript-ant-design/renderer/pages/home.tsx
+++ b/examples/with-typescript-ant-design/renderer/pages/home.tsx
@@ -1,0 +1,95 @@
+import React from 'react';
+import Link from 'next/link';
+import {
+  Layout,
+  Form,
+  Select,
+  InputNumber,
+  DatePicker,
+  Switch,
+  Slider,
+  Button,
+} from 'antd';
+
+const {
+  Header,
+  Content,
+} = Layout;
+const { Item: FormItem } = Form;
+const { Option } = Select;
+
+const Home = () => {
+  return (
+    <React.Fragment>
+  
+      <Header>
+        <Link href="/next">
+          <a>Go to next page</a>
+        </Link>
+      </Header>
+  
+      <Content style={{ padding: 48 }}>
+        <Form layout='horizontal'>
+          <FormItem
+            label='Input Number'
+            labelCol={{ span: 8 }}
+            wrapperCol={{ span: 8 }}
+          >
+            <InputNumber size='large' min={1} max={10} style={{ width: 100 }} defaultValue={3} name='inputNumber' />
+            <a href='#'>Link</a>
+          </FormItem>
+  
+          <FormItem
+            label='Switch'
+            labelCol={{ span: 8 }}
+            wrapperCol={{ span: 8 }}
+          >
+            <Switch defaultChecked name='switch' />
+          </FormItem>
+  
+          <FormItem
+            label='Slider'
+            labelCol={{ span: 8 }}
+            wrapperCol={{ span: 8 }}
+          >
+            <Slider defaultValue={70} />
+          </FormItem>
+  
+          <FormItem
+            label='Select'
+            labelCol={{ span: 8 }}
+            wrapperCol={{ span: 8 }}
+          >
+            <Select size='large' defaultValue='lucy' style={{ width: 192 }} name='select'>
+              <Option value='jack'>jack</Option>
+              <Option value='lucy'>lucy</Option>
+              <Option value='disabled' disabled>disabled</Option>
+              <Option value='yiminghe'>yiminghe</Option>
+            </Select>
+          </FormItem>
+  
+          <FormItem
+            label='DatePicker'
+            labelCol={{ span: 8 }}
+            wrapperCol={{ span: 8 }}
+          >
+            <DatePicker name='startDate' />
+          </FormItem>
+          <FormItem
+            style={{ marginTop: 48 }}
+            wrapperCol={{ span: 8, offset: 8 }}
+          >
+            <Button size='large' type='primary' htmlType='submit'>
+            OK
+            </Button>
+            <Button size='large' style={{ marginLeft: 8 }}>
+            Cancel
+            </Button>
+          </FormItem>
+        </Form>
+      </Content>
+    </React.Fragment>
+  );
+};
+
+export default Home;

--- a/examples/with-typescript-ant-design/renderer/pages/next.tsx
+++ b/examples/with-typescript-ant-design/renderer/pages/next.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import Link from 'next/link';
+import {
+  Layout,
+  Result,
+} from 'antd';
+
+const {
+  Header,
+  Content,
+} = Layout;
+
+const Next = () => {
+  return (
+    <React.Fragment>
+
+      <Header>
+        <Link href="/home">
+          <a>Go to home page</a>
+        </Link>
+      </Header>
+
+      <Content style={{ padding: 48 }}>
+        <Result
+          status="success"
+          title="Nextron"
+          subTitle="with Ant Design"
+        />
+      </Content>
+      
+    </React.Fragment>
+  );
+};
+
+export default Next;

--- a/examples/with-typescript-ant-design/renderer/tsconfig.json
+++ b/examples/with-typescript-ant-design/renderer/tsconfig.json
@@ -1,0 +1,11 @@
+{
+    "extends": "../tsconfig.json",
+    "include": [
+      "next-env.d.ts",
+      "**/*.ts",
+      "**/*.tsx"
+    ],
+    "exclude": [
+      "node_modules"
+    ]
+}

--- a/examples/with-typescript-ant-design/tsconfig.json
+++ b/examples/with-typescript-ant-design/tsconfig.json
@@ -1,0 +1,27 @@
+{
+    "compilerOptions": {
+      "target": "es5",
+      "module": "esnext",
+      "moduleResolution": "node",
+      "jsx": "preserve",
+      "lib": [
+        "dom",
+        "dom.iterable",
+        "esnext"
+      ],
+      "allowJs": true,
+      "skipLibCheck": true,
+      "strict": false,
+      "forceConsistentCasingInFileNames": true,
+      "noEmit": true,
+      "esModuleInterop": true,
+      "resolveJsonModule": true,
+      "isolatedModules": true
+    },
+    "exclude": [
+      "node_modules",
+      "renderer/next.config.js",
+      "app",
+      "dist"
+    ]
+}


### PR DESCRIPTION
This pull request adds typescript to  with-javascript-ant-design example. It also imports ant-design style in a custom `_app.tsx` so you don't need to do it on every page.