### PR TITLE
Update createMuiTheme To createTheme

### DIFF
--- a/examples/with-typescript-material-ui/renderer/lib/theme.ts
+++ b/examples/with-typescript-material-ui/renderer/lib/theme.ts
@@ -1,7 +1,7 @@
-import { createMuiTheme } from '@material-ui/core/styles';
+import { createTheme } from '@material-ui/core/styles';
 import red from '@material-ui/core/colors/red';
 
-export const theme = createMuiTheme({
+export const theme = createTheme({
   palette: {
     primary: {
       main: '#556cd6',


### PR DESCRIPTION
In examples/with-typescript-material-ui

There is an error message.
```
createTheme.js:94 Material-UI: the createMuiTheme function was renamed to createTheme.

You should use `import { createTheme } from '@material-ui/core/styles'`
```

Accordingly, I've changed *import { createMuiTheme }* to *import { createTheme }* in an example with-typescript-material-ui.