### PR TITLE
create-window.js fixed for BrowserWindow options

### DIFF
--- a/examples/_template/js/main/helpers/create-window.js
+++ b/examples/_template/js/main/helpers/create-window.js
@@ -67,8 +67,8 @@ export default function createWindow(windowName, options) {
   state = ensureVisibleOnSomeDisplay(restore());
 
   win = new BrowserWindow({
-    ...options,
     ...state,
+    ...options,
     webPreferences: {
       nodeIntegration: true,
       contextIsolation: false,

--- a/examples/_template/ts/main/helpers/create-window.ts
+++ b/examples/_template/ts/main/helpers/create-window.ts
@@ -68,8 +68,8 @@ export default (windowName: string, options: BrowserWindowConstructorOptions): B
   state = ensureVisibleOnSomeDisplay(restore());
 
   const browserOptions: BrowserWindowConstructorOptions = {
-    ...options,
     ...state,
+    ...options,
     webPreferences: {
       nodeIntegration: true,
       contextIsolation: false,


### PR DESCRIPTION
User settings are ignored when creating "BrowserWindow". A minor change had to be made to rectify this situation. I made this fix.