### PR TITLE
Allow configuration of `app` directory for Next.js 13

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,10 @@ module.exports = {
   mainSrcDir: 'main',
   // specify an alternate renderer src directory, defaults to 'renderer'
   rendererSrcDir: 'renderer',
+  
+  // specify an alternate app build directory, defaults to 'app'. 
+  // Next.js 13 reserves 'app', so you can change this to e.g. 'app-build'
+  appSrcDir: 'app'
 
   // main process' webpack config
   webpack: (config, env) => {

--- a/examples/_template/js/main/background.js
+++ b/examples/_template/js/main/background.js
@@ -5,6 +5,8 @@ import { createWindow } from './helpers';
 const isProd = process.env.NODE_ENV === 'production';
 
 if (isProd) {
+  // if you set `appSrcDir` in `nextron.config.js`
+  // Remember to change directory here to match `appSrcDir`
   serve({ directory: 'app' });
 } else {
   app.setPath('userData', `${app.getPath('userData')} (development)`);

--- a/examples/_template/ts/main/background.ts
+++ b/examples/_template/ts/main/background.ts
@@ -5,6 +5,8 @@ import { createWindow } from './helpers';
 const isProd: boolean = process.env.NODE_ENV === 'production';
 
 if (isProd) {
+  // if you set `appSrcDir` in `nextron.config.js`
+  // Remember to change directory here to match `appSrcDir`
   serve({ directory: 'app' });
 } else {
   app.setPath('userData', `${app.getPath('userData')} (development)`);

--- a/examples/ipc-communication/main/background.js
+++ b/examples/ipc-communication/main/background.js
@@ -5,6 +5,8 @@ import { createWindow } from './helpers';
 const isProd = process.env.NODE_ENV === 'production';
 
 if (isProd) {
+  // if you set `appSrcDir` in `nextron.config.js`
+  // Remember to change directory here to match `appSrcDir`
   serve({ directory: 'app' });
 } else {
   app.setPath('userData', `${app.getPath('userData')} (development)`);

--- a/examples/store-data/main/background.js
+++ b/examples/store-data/main/background.js
@@ -6,6 +6,8 @@ import { createWindow } from './helpers';
 const isProd = process.env.NODE_ENV === 'production';
 
 if (isProd) {
+  // if you set `appSrcDir` in `nextron.config.js`
+  // Remember to change directory here to match `appSrcDir`
   serve({ directory: 'app' });
 } else {
   app.setPath('userData', `${app.getPath('userData')} (development)`);

--- a/lib/nextron-build.ts
+++ b/lib/nextron-build.ts
@@ -70,9 +70,14 @@ async function build() {
   // Ignore missing dependencies
   process.env.ELECTRON_BUILDER_ALLOW_UNRESOLVED_DEPENDENCIES = 'true';
 
-  const appdir = path.join(cwd, 'app');
-  const distdir = path.join(cwd, 'dist');
-  const rendererSrcDir = getNextronConfig().rendererSrcDir || 'renderer';
+  const nextronConfig = getNextronConfig();
+
+  const distDir = nextronConfig.distDir || 'dist';
+  const appSrcDir = nextronConfig.appSrcDir || 'app';
+  const rendererSrcDir = nextronConfig.rendererSrcDir || 'renderer';
+
+  const appdir = path.join(cwd, appSrcDir);
+  const distdir = path.join(cwd, distDir);
 
   try {
     log('Clearing previous builds');

--- a/lib/webpack/helpers.ts
+++ b/lib/webpack/helpers.ts
@@ -3,6 +3,15 @@ import path from 'path';
 import { merge } from 'webpack-merge';
 import configure from './webpack.config';
 
+interface NextronConfig {
+  rendererSrcDir?: string;
+  appSrcDir?: string;
+  mainSrcDir?: string;
+  distDir?: string;
+  startupDelay?: number;
+  webpack?: (config: any, options: any) => any;
+}
+
 const existsSync = (f: string): boolean => {
   try {
     fs.accessSync(f, fs.constants.F_OK);
@@ -15,7 +24,7 @@ const existsSync = (f: string): boolean => {
 const cwd = process.cwd();
 const ext = existsSync(path.join(cwd, 'tsconfig.json')) ? '.ts' : '.js';
 
-export const getNextronConfig = () => {
+export const getNextronConfig = (): NextronConfig => {
   const nextronConfigPath = path.join(cwd, 'nextron.config.js');
   if (existsSync(nextronConfigPath)) {
     return require(nextronConfigPath);
@@ -25,14 +34,14 @@ export const getNextronConfig = () => {
 };
 
 export const getWebpackConfig = (env: 'development' | 'production') => {
-  const { mainSrcDir, webpack } = getNextronConfig();
+  const { mainSrcDir, webpack, appSrcDir } = getNextronConfig();
   const userConfig = merge(configure(env), {
     entry: {
       background: path.join(cwd, mainSrcDir || 'main', `background${ext}`),
     },
     output: {
       filename: '[name].js',
-      path: path.join(cwd, 'app'),
+      path: path.join(cwd, appSrcDir || 'app'),
     },
   });
 

--- a/lib/webpack/webpack.config.ts
+++ b/lib/webpack/webpack.config.ts
@@ -1,6 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 import webpack from 'webpack';
+import { getNextronConfig } from './helpers';
 
 const cwd = process.cwd();
 const externals = require(path.join(cwd, 'package.json')).dependencies;
@@ -21,43 +22,46 @@ const getBabelrc = (): string | undefined => {
   return path.join(__dirname, '../babel.js');
 };
 
-export default (env: 'development' | 'production'): webpack.Configuration => ({
-  mode: env,
-  target: 'electron-main',
-  node: {
-    __dirname: false,
-    __filename: false,
-  },
-  externals: [...Object.keys(externals || {})],
-  devtool: 'source-map',
-  resolve: {
-    extensions: ['.js', '.jsx', '.json', '.ts', '.tsx'],
-    modules: [path.join(cwd, 'app'), 'node_modules'],
-  },
-  output: {
-    libraryTarget: 'commonjs2',
-  },
-  module: {
-    rules: [
-      {
-        test: /\.(js|ts)x?$/,
-        use: {
-          loader: require.resolve('babel-loader'),
-          options: {
-            cacheDirectory: true,
-            extends: getBabelrc(),
+export default (env: 'development' | 'production'): webpack.Configuration => {
+  const nextronConfig = getNextronConfig();
+  return {
+    mode: env,
+    target: 'electron-main',
+    node: {
+      __dirname: false,
+      __filename: false,
+    },
+    externals: [...Object.keys(externals || {})],
+    devtool: 'source-map',
+    resolve: {
+      extensions: ['.js', '.jsx', '.json', '.ts', '.tsx'],
+      modules: [path.join(cwd, nextronConfig.appSrcDir || 'app'), 'node_modules'],
+    },
+    output: {
+      libraryTarget: 'commonjs2',
+    },
+    module: {
+      rules: [
+        {
+          test: /\.(js|ts)x?$/,
+          use: {
+            loader: require.resolve('babel-loader'),
+            options: {
+              cacheDirectory: true,
+              extends: getBabelrc(),
+            },
           },
+          exclude: [
+            /node_modules/,
+            path.join(cwd, nextronConfig.rendererSrcDir || 'renderer'),
+          ],
         },
-        exclude: [
-          /node_modules/,
-          path.join(cwd, 'renderer'),
-        ],
-      },
+      ],
+    },
+    plugins: [
+      new webpack.EnvironmentPlugin({
+        NODE_ENV: env,
+      }),
     ],
-  },
-  plugins: [
-    new webpack.EnvironmentPlugin({
-      NODE_ENV: env,
-    }),
-  ],
-});
+  }
+};


### PR DESCRIPTION
* Next.js 13 reserves the `app` directory
* Nextron uses the `app` directory.

With this change, nextron users can set `appSrcDir` in `nextron.config.js` and then update the 'app' string in their `background.ts` file.

I wasn't sure how to thread the nextron config into `background.ts`, but I added comments in the templates for new project creators.

Should close https://github.com/saltyshiomix/nextron/issues/311