### PR TITLE
feat: update gitignore template to include `next-env.d.ts` as it shouldn't be committed

### DIFF
--- a/examples/_template/gitignore.txt
+++ b/examples/_template/gitignore.txt
@@ -1,5 +1,13 @@
+# dependencies
 node_modules
+
+# logs
 *.log
+
+# next.js
 .next
+next-env.d.ts
+
+# build
 app
 dist


### PR DESCRIPTION
Next.js generates `next-env.d.ts` during for the typescript types of Next.

![image](https://github.com/saltyshiomix/nextron/assets/67187467/2f3873ff-69d2-4fb0-a726-9cab62603c08)

This file shouldn't be committed as it is regenerated on each build