### PR TITLE
Fix gitignore in template to only ignore root app directory

### DIFF
--- a/examples/_template/gitignore.txt
+++ b/examples/_template/gitignore.txt
@@ -9,5 +9,5 @@ node_modules
 next-env.d.ts
 
 # build
-app
+/app
 dist


### PR DESCRIPTION
### Summary
This PR addresses an issue with the `.gitignore` file generated by the `npx create-nextron-app` command. The current configuration ignores all directories named `app` throughout the project, which can lead to unintended ignoring of important files in nested directories. This PR modifies the `.gitignore` configuration to only ignore the `app` directory at the root of the project.

### Changes
- Updated the `.gitignore` entry from `app` to `/app` in the `examples/_template/gitignore.txt` file.

### Issue
Fixes #452