### PR TITLE
fix: vscode debug

### DIFF
--- a/lib/nextron-dev.ts
+++ b/lib/nextron-dev.ts
@@ -70,7 +70,7 @@ const execaOptions: execa.Options = {
     )
     mainProcess = execa(
       'electron',
-      ['.', `${rendererPort}`, `${electronOptions}`],
+      ['.', `${rendererPort}`, ...electronOptions.split(' ')],
       {
         detached: true,
         ...execaOptions,


### PR DESCRIPTION
Fix: debug by vscode

The library `execa`  was used error about params

This PR fixes #474 